### PR TITLE
カスタムリソース削除時にリポジトリが削除済みだったらDeleteRepoせずに終了する

### DIFF
--- a/pkg/controller/github_repository/github_repository_controller.go
+++ b/pkg/controller/github_repository/github_repository_controller.go
@@ -191,6 +191,13 @@ func (r *ReconcileGitHub) runFinalizer(instannce *showksv1beta1.GitHubRepository
 
 func (r *ReconcileGitHub) deleteExternalDependency(instance *showksv1beta1.GitHubRepository) error {
 	fmt.Println("deleteExternalDependency")
+	_, err := r.ghClient.GetRepository(instance.Spec.Org, instance.Spec.Name)
+	if err != nil {
+		if _, ok := err.(*gh.NotFoundError); ok {
+			return nil
+		}
+		return nil
+	}
 	return r.ghClient.DeleteRepository(instance.Spec.Org, instance.Spec.Name)
 }
 

--- a/pkg/controller/github_repository/github_repository_controller.go
+++ b/pkg/controller/github_repository/github_repository_controller.go
@@ -196,7 +196,7 @@ func (r *ReconcileGitHub) deleteExternalDependency(instance *showksv1beta1.GitHu
 		if _, ok := err.(*gh.NotFoundError); ok {
 			return nil
 		}
-		return nil
+		return err
 	}
 	return r.ghClient.DeleteRepository(instance.Spec.Org, instance.Spec.Name)
 }

--- a/pkg/controller/github_repository/github_repository_controller_test.go
+++ b/pkg/controller/github_repository/github_repository_controller_test.go
@@ -54,7 +54,8 @@ func newGitHubClientMock(controller *gomock.Controller) gh.GitHubClientInterface
 	c.EXPECT().DeleteRepository(org, repoName).Return(nil).Times(1)
 
 	firstGetRepo := c.EXPECT().GetRepository(org, repoName).Return(nil, &gh.NotFoundError{}).Times(1)
-	c.EXPECT().GetRepository(org, repoName).Return(repoResp, nil).After(firstGetRepo).Times(1)
+	secondGetRepo := c.EXPECT().GetRepository(org, repoName).Return(repoResp, nil).After(firstGetRepo).Times(1)
+	c.EXPECT().GetRepository(org, repoName).Return(repoResp, nil).After(secondGetRepo).Times(1)
 	rs := showksv1beta1.GitHubRepositorySpec{
 		Org:  org,
 		Name: repoName,


### PR DESCRIPTION
削除済みのリポジトリを無限に消そうとするのを防ぎます